### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# IntelliJ IDEA
+.idea/
+.consulo/
+*.iml
+
+# JARs containing copyrighted code
+libs/bta.jar
+libs/bta_server.jar
+
+# Binary files and working folder
+.gradle/
+bin/
+build/
+out/
+run/
+
+# Gradle Wrapper should not be ignored
+!gradle/wrapper/
+!gradlew
+!build.gradle
+!gradle.properties
+!gradlew.bat
+!settings.gradle
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*


### PR DESCRIPTION
`.gitignore` configuration files are essential to prevent leakage of useless, unnecessary, or copyrighted files.